### PR TITLE
hide firebase key in the repo secrets

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -20,7 +20,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyAd5KAYDuxrMcP2QCm4sp4gdxUZ0BdJSZ0"
+          "current_key": "$FIREBASE_KEY$"
         }
       ],
       "services": {


### PR DESCRIPTION
once we have a build job/workflow, this placeholder needs to be replaced with the value from the secret "FIREBASE_KEY"